### PR TITLE
add eval template API

### DIFF
--- a/pages/api/eval-template.ts
+++ b/pages/api/eval-template.ts
@@ -1,0 +1,60 @@
+import { NextApiRequest, NextApiResponse } from "next";
+import rankEval from "../../rank_eval.json";
+
+function getAuthCreds(authHeader: string): { user: string; password: string } {
+  const [, base64Creds] = authHeader.split(" ");
+  const creds = new Buffer(base64Creds, "base64").toString("utf-8");
+  const [user, password] = creds.split(":");
+  return {
+    user,
+    password,
+  };
+}
+
+export default async (req: NextApiRequest, res: NextApiResponse) => {
+  const template = req.body;
+  const authCreds =
+    req.headers.authorization && typeof req.headers.authorization === "string"
+      ? getAuthCreds(req.headers.authorization)
+      : undefined;
+
+  const { RANK_EVAL_USER, RANK_EVAL_PASSWORD } = process.env;
+
+  console.info(RANK_EVAL_USER, RANK_EVAL_PASSWORD, authCreds, req.headers);
+  if (
+    authCreds &&
+    authCreds.user === RANK_EVAL_USER &&
+    authCreds.password === RANK_EVAL_PASSWORD
+  ) {
+    const { ES_USER, ES_PASSWORD, ES_URL } = process.env;
+    const rankEvalEnpoint = `https://${ES_URL}/works_prod/_rank_eval`;
+    const templateId = template.id;
+    const rankEvalRequestsWithNewTemplateId = rankEval.requests.map(
+      (request) => ({ ...request, template_id: templateId })
+    );
+    const newRankEval = {
+      ...rankEval,
+      requests: rankEvalRequestsWithNewTemplateId,
+    };
+    console.info({ ...newRankEval, templates: [template] });
+    const resp = await fetch(rankEvalEnpoint, {
+      method: "POST",
+      body: JSON.stringify({ ...newRankEval, templates: [template] }),
+      headers: {
+        Authorization: `Basic ${Buffer.from(
+          `${ES_USER}:${ES_PASSWORD}`
+        ).toString("base64")}`,
+        "Content-Type": "application/json",
+      },
+    });
+    const json = await resp.json();
+
+    res.statusCode = 200;
+    res.setHeader("Content-Type", "application/json");
+    res.end(JSON.stringify(json));
+  } else {
+    res.statusCode = 400;
+    res.setHeader("Content-Type", "application/json");
+    res.end(JSON.stringify({ message: "Come again soon" }));
+  }
+};

--- a/test_search_template.json
+++ b/test_search_template.json
@@ -1,0 +1,22 @@
+{
+  "id": "title_match",
+  "template": {
+    "source": {
+      "query": {
+        "bool": {
+          "should": [
+            {
+              "prefix": {
+                "data.title.keyword": {
+                  "value": "{{query}}",
+                  "boost": 1000
+                }
+              }
+            }
+          ]
+        }
+      },
+      "track_total_hits": true
+    }
+  }
+}


### PR DESCRIPTION
Adds an API, with basic auth to allow clients to send a template, which will be validated against the tests and rankings.

And example request might look like:
```
curl 'http://localhost:3000/api/eval-template'  -H 'content-type: application/json' -H 'Authorization: Basic blahblah' -d '{ "id": "title_match", "template": { "source": { "query": { "bool": { "should": [ { "prefix": { "data.title.keyword": { "value": "{{query}}", "boost": 1000 } } } ] } }, "track_total_hits": true } } }'
```