### PR TITLE
add rank eval to search to be able to use test queries

### DIFF
--- a/components/QueryIdSelect.tsx
+++ b/components/QueryIdSelect.tsx
@@ -1,0 +1,24 @@
+import { useState } from "react";
+
+type Props = {
+  queryId?: string;
+};
+const QueryIdSelect = (props: Props) => {
+  const [queryId, setQueryId] = useState(props.queryId);
+  return (
+    <label className="p-2 mr-10 inline-block border-2 border-purple-400 rounded-full">
+      Query ID:
+      <select
+        className="ml-2"
+        name="queryId"
+        onChange={(event) => setQueryId(event.currentTarget.value)}
+        value={queryId}
+      >
+        <option value="">default</option>
+        <option value="languages">languages</option>
+      </select>
+    </label>
+  );
+};
+
+export default QueryIdSelect;

--- a/components/Submit.tsx
+++ b/components/Submit.tsx
@@ -1,0 +1,13 @@
+const Submit = () => {
+  return (
+    <button
+      className="p-2 ml-3 mr-10 inline-block border-2 border-purple-400 rounded-full"
+      aria-label="Search catalogue"
+      type="submit"
+    >
+      🔎
+    </button>
+  );
+};
+
+export default Submit;

--- a/pages/api/eval.ts
+++ b/pages/api/eval.ts
@@ -54,7 +54,7 @@ export type RankEvalResponse = {
   };
 };
 
-async function makeRankEvalRequest(
+export async function makeRankEvalRequest(
   template: Template
 ): Promise<RankEvalResponse> {
   const queryType = indexToQueryType(template.index);


### PR DESCRIPTION
Allows us to run our rank_eval tests against test queries before promoting to the API.

CSS will need some tidying soon (or not), also needs types from elastic (or not)

![Screenshot 2021-03-24 at 12 13 52](https://user-images.githubusercontent.com/31692/112308772-6c9cce00-8c9a-11eb-9e7a-2f4024397a14.png)
