### PR TITLE
use explain on hits

### DIFF
--- a/components/QueryIdSelect.tsx
+++ b/components/QueryIdSelect.tsx
@@ -16,6 +16,7 @@ const QueryIdSelect = (props: Props) => {
       >
         <option value="">default</option>
         <option value="languages">languages</option>
+        <option value="exact-title-match">exact-title-match</option>
       </select>
     </label>
   );

--- a/pages/api/search/works.ts
+++ b/pages/api/search/works.ts
@@ -37,18 +37,14 @@ export default async (req: NextApiRequest, res: NextApiResponse) => {
   const searchReq = client.searchTemplate({
     index: template.index,
     body: {
+      explain: true,
       source: {
         ...template.template.source,
         track_total_hits: true,
         highlight: {
           pre_tags: ['<em class="bg-yellow-200">'],
           post_tags: ["</em>"],
-          fields: {
-            "data.title": { number_of_fragments: 0 },
-            "data.contributors.agent.label": { number_of_fragments: 0 },
-            "data.subjects.concepts.label": { number_of_fragments: 0 },
-            "data.genres.concepts.label": { number_of_fragments: 0 },
-          },
+          fields: { "*": { number_of_fragments: 0 } },
         },
       },
       params: {

--- a/pages/search.tsx
+++ b/pages/search.tsx
@@ -4,7 +4,6 @@ import Link from "next/link";
 import absoluteUrl from "next-absolute-url";
 import QueryIdSelect from "../components/QueryIdSelect";
 import Submit from "../components/Submit";
-import { highlightFields } from "../services/search";
 
 type Props = {
   data?: any;

--- a/queries/exact-title-match.ts
+++ b/queries/exact-title-match.ts
@@ -1,0 +1,81 @@
+const query = {
+  bool: {
+    should: [
+      {
+        prefix: {
+          "data.title.keyword": {
+            _name: "exact_title",
+            value: "{{query}}",
+            boost: 1000,
+          },
+        },
+      },
+      {
+        multi_match: {
+          query: "{{query}}",
+          fields: [
+            "state.canonicalId^1000.0",
+            "state.sourceIdentifier.value^1000.0",
+            "data.otherIdentifiers.value^1000.0",
+            "data.items.id.canonicalId^1000.0",
+            "data.items.id.sourceIdentifier.value^1000.0",
+            "data.items.id.otherIdentifiers.value^1000.0",
+            "data.imageData.id.canonicalId^1000.0",
+            "data.imageData.id.sourceIdentifier.value^1000.0",
+            "data.imageData.id.otherIdentifiers.value^1000.0",
+          ],
+          type: "best_fields",
+          analyzer: "whitespace_analyzer",
+          operator: "Or",
+        },
+      },
+      {
+        multi_match: {
+          query: "{{query}}",
+          fields: [
+            "data.title^100.0",
+            "data.title.english^100.0",
+            "data.title.shingles^100.0",
+            "data.alternativeTitles^100.0",
+            "data.lettering",
+          ],
+          type: "best_fields",
+          fuzziness: "AUTO",
+          operator: "And",
+        },
+      },
+      {
+        multi_match: {
+          query: "{{query}}",
+          fields: [
+            "data.contributors.agent.label^1000.0",
+            "data.subjects.concepts.label^10.0",
+            "data.genres.concepts.label^10.0",
+            "data.production.*.label^10.0",
+            "data.description",
+            "data.physicalDescription",
+            "data.language.label",
+            "data.edition",
+            "data.notes.content",
+            "data.collectionPath.path",
+            "data.collectionPath.label",
+          ],
+          type: "cross_fields",
+          operator: "And",
+        },
+      },
+    ],
+    filter: [
+      {
+        term: {
+          type: {
+            value: "Visible",
+          },
+        },
+      },
+    ],
+    minimum_should_match: "1",
+  },
+};
+
+export default query;


### PR DESCRIPTION
Adds `explain` (behind a click) - and also a more verbose field highlighting.
![Screenshot 2021-03-25 at 10 03 29](https://user-images.githubusercontent.com/31692/112455174-60277c80-8d51-11eb-8481-ef2b1ab72624.png)
 