### PR TITLE
use a match_all query if we have no query to match on

### DIFF
--- a/pages/api/search/works.ts
+++ b/pages/api/search/works.ts
@@ -37,7 +37,6 @@ export default async (req: NextApiRequest, res: NextApiResponse) => {
   const rankEvalReqs = rankEvalRequests(template);
   const searchQuery = query ? template : await getTestQuery("match-all");
 
-  console.info(searchQuery);
   const searchReq = client.searchTemplate({
     index: template.index,
     body: {

--- a/pages/api/search/works.ts
+++ b/pages/api/search/works.ts
@@ -35,12 +35,15 @@ export default async (req: NextApiRequest, res: NextApiResponse) => {
     : await getCurrentQuery();
 
   const rankEvalReqs = rankEvalRequests(template);
+  const searchQuery = query ? template : await getTestQuery("match-all");
+
+  console.info(searchQuery);
   const searchReq = client.searchTemplate({
     index: template.index,
     body: {
       explain: true,
       source: {
-        ...template.template.source,
+        ...searchQuery.template.source,
         track_total_hits: true,
         highlight: {
           pre_tags: ['<em class="bg-yellow-200">'],

--- a/queries/match-all.ts
+++ b/queries/match-all.ts
@@ -1,0 +1,15 @@
+const query = {
+  bool: {
+    filter: [
+      {
+        term: {
+          type: {
+            value: "Visible",
+          },
+        },
+      },
+    ],
+  },
+};
+
+export default query;


### PR DESCRIPTION
Stops us running long running queries when we have no search term