### PR TITLE
change queryIds to reflect what's actually being measured

### DIFF
--- a/pages/api/eval.ts
+++ b/pages/api/eval.ts
@@ -1,6 +1,7 @@
 import { Env, Example } from "../../types";
 import { NextApiRequest, NextApiResponse } from "next";
 import { Template, getSearchTemplates } from "../../services/search-templates";
+
 import { client } from "../../services/elasticsearch";
 import { indexToQueryType } from "../index";
 
@@ -63,6 +64,7 @@ export async function rankEvalRequest(
   const { default: ratings } = await import(
     `../../data/ratings/${queryType}/${moduleName}`
   );
+
   const requests = formatExamples(
     ratings.examples,
     template.index,
@@ -88,7 +90,7 @@ export async function rankEvalRequest(
     .then((resp) => {
       return {
         ...resp.body,
-        queryId: template.id,
+        queryId: `${queryType}-${moduleName}`,
         index: template.index,
         query: {
           method: "POST",

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -122,7 +122,7 @@ const RankingComponent = ({ ranking }: RankingComponentProps) => {
   );
 };
 
-const Index: NextPage<Props> = ({ data: { pass, rankings }, search }) => {
+const Index: NextPage<Props> = ({ data: { rankings } }) => {
   return (
     <>
       <Head>


### PR DESCRIPTION
index page headings are now a better reflection of what's actually being measured in each block:


![Screenshot 2021-03-31 at 15 08 22](https://user-images.githubusercontent.com/11006680/113157631-fa486280-9232-11eb-993f-1c47d3ae6fa1.png)
